### PR TITLE
Revamped Student & Owner Plans UI: Removed Buttons and Simplified Layout

### DIFF
--- a/src/app/owners/page.tsx
+++ b/src/app/owners/page.tsx
@@ -1,124 +1,108 @@
-// src/app/owners/page.tsx
+'use client';
+
+import { FaLightbulb, FaChartLine, FaRocket } from 'react-icons/fa';
+import { motion } from 'framer-motion';
 
 export default function OwnerPlansPage() {
   return (
-    <div className="bg-blue-600 min-h-screen text-white font-sans">
-      <div className="max-w-6xl mx-auto px-6 py-12">
-        <h1 className="text-4xl font-bold text-center mb-12">Choose the Livaro that works for your needs</h1>
+    <div className="bg-gray-100 text-gray-900 min-h-screen font-sans">
+      {/* Heading */}
+      <div className="max-w-6xl mx-auto px-6 py-16 text-center">
+        <h1 className="text-4xl md:text-5xl font-bold mb-4">
+          Livaro Owner Plans
+        </h1>
+        <p className="text-lg text-gray-600">
+          Manage your rental properties with ease and efficiency
+        </p>
+      </div>
 
-        {/* Plan Cards */}
+      {/* Plan Cards */}
+      <div className="max-w-6xl mx-auto px-6 py-10">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {/* Basic Plan */}
-          <div className="bg-white text-black p-6 rounded-xl shadow-md flex flex-col items-center transform transition duration-300 hover:scale-105 hover:shadow-2xl">
-            <div className="text-2xl font-semibold mb-2">01</div>
-            <button className="text-blue-600 font-bold bg-blue-100 px-4 py-1 rounded-full mb-4">Basic - Free</button>
-            <p className="text-center mb-4">Perfect for getting started with basic property management features.</p>
-            <ul className="text-green-700 space-y-2 mb-6">
-              <li>✔️ Ask tenants to resolve concerns 24/7</li>
-              <li>✔️ Handle rent collection outreach</li>
-              <li>✔️ Schedule showings and maintenance</li>
-              <li>✔️ Basic tenant communication</li>
-            </ul>
-            <button className="border border-blue-600 text-blue-600 px-6 py-2 rounded hover:bg-blue-50">Get Started</button>
-          </div>
-
-          {/* Growth Plan */}
-          <div className="bg-white text-black p-6 rounded-xl shadow-md flex flex-col items-center transform transition duration-300 hover:scale-105 hover:shadow-2xl">
-            <div className="absolute -top-4 px-4 py-1 text-sm bg-orange-500 text-white rounded-full">Best Value</div>
-            <div className="text-2xl font-semibold mb-2">02</div>
-            <button className="text-blue-600 font-bold bg-blue-100 px-4 py-1 rounded-full mb-4">Growth - $29.99/month</button>
-            <p className="text-center mb-4">Ideal for growing property portfolios with advanced automation.</p>
-            <ul className="text-green-700 space-y-2 mb-6">
-              <li>✔️ Everything in Basic</li>
-              <li>✔️ Property monitoring & maintenance alerts</li>
-              <li>✔️ Livaro Rewards for tenants</li>
-              <li>✔️ Live audio chat for showings</li>
-              <li>✔️ Advanced automation features</li>
-            </ul>
-            <button className="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">Start Free Trial</button>
-          </div>
-
-          {/* Pro Plan */}
-          <div className="bg-white text-black p-6 rounded-xl shadow-md flex flex-col items-center transform transition duration-300 hover:scale-105 hover:shadow-2xl">
-            <div className="text-2xl font-semibold mb-2">03</div>
-            <button className="text-blue-600 font-bold bg-blue-100 px-4 py-1 rounded-full mb-4">Pro - $59.99/month</button>
-            <p className="text-center mb-4">Complete hands-off property management for serious investors.</p>
-            <ul className="text-green-700 space-y-2 mb-6">
-              <li>✔️ Everything in Growth</li>
-              <li>✔️ Full tenant placement & screening</li>
-              <li>✔️ Complete rent collection management</li>
-              <li>✔️ Dispute resolution handling</li>
-              <li>✔️ Hands-off property management</li>
-            </ul>
-            <button className="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">Contact Sales</button>
-          </div>
+          {/* Card Variants */}
+          {[{
+            icon: <FaLightbulb className="text-yellow-400 text-4xl mb-3" />,
+            title: "Basic",
+            desc: "For individual landlords just getting started.",
+            features: [
+              "24/7 tenant concern resolution",
+              "Rent collection outreach",
+              "Schedule maintenance & showings",
+              "Basic communication tools"
+            ]
+          },
+          {
+            icon: <FaChartLine className="text-orange-500 text-4xl mb-3" />,
+            title: "Growth",
+            desc: "For landlords scaling up with more properties.",
+            features: [
+              "Everything in Basic",
+              "Property alerts & monitoring",
+              "Livaro Rewards for tenants",
+              "Audio chat for showings",
+              "Automation tools"
+            ]
+          },
+          {
+            icon: <FaRocket className="text-purple-600 text-4xl mb-3" />,
+            title: "Pro",
+            desc: "Complete hands-off property management.",
+            features: [
+              "Everything in Growth",
+              "Tenant placement & screening",
+              "Rent collection management",
+              "Dispute resolution",
+              "End-to-end automation"
+            ]
+          }].map((plan, index) => (
+            <motion.div
+              key={index}
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.98 }}
+              transition={{ type: 'spring', stiffness: 300 }}
+              className="bg-white rounded-2xl p-8 shadow-lg hover:shadow-xl transition"
+            >
+              <div className="flex flex-col items-center">
+                {plan.icon}
+                <h3 className="text-2xl font-semibold mb-2 text-gray-800">{plan.title}</h3>
+                <p className="text-sm text-gray-500 mb-4 text-center">{plan.desc}</p>
+                <ul className="text-gray-700 text-sm text-left mt-4 space-y-2">
+                  {plan.features.map((f, i) => (
+                    <li key={i}>✔️ {f}</li>
+                  ))}
+                </ul>
+              </div>
+            </motion.div>
+          ))}
         </div>
       </div>
 
-      {/* Comparison Table */}
-      <div className="bg-white text-black py-12 px-6">
-        <h2 className="text-3xl font-bold text-center mb-8">What you get with each plan</h2>
-        <div className="overflow-x-auto max-w-6xl mx-auto">
-          <table className="w-full border-collapse">
-            <thead>
-              <tr className="bg-blue-50 text-left">
-                <th className="p-4">Features</th>
-                <th className="p-4 text-center">Basic</th>
-                <th className="p-4 text-center">
-                  Pro <span className="text-orange-500 font-semibold text-sm">Best Value</span>
-                </th>
-                <th className="p-4 text-center">Complete</th>
-              </tr>
-            </thead>
-            <tbody>
-              {[
-                {
-                  name: 'Ask tenants to resolve concerns and questions 24/7 every day',
-                  basic: true, pro: true, complete: true
-                },
-                {
-                  name: 'Ask renters to resolving issues & disputes on their own',
-                  basic: true, pro: true, complete: true
-                },
-                {
-                  name: 'Handles outreach for rent, lease renewals, and delinquent payments',
-                  basic: true, pro: true, complete: true
-                },
-                {
-                  name: 'Schedules showings, maintenance, and walk-throughs',
-                  basic: true, pro: true, complete: true
-                },
-                {
-                  name: 'Monitors your property & renter concerns to suggest preventative maintenance & actions',
-                  basic: false, pro: true, complete: true
-                },
-                {
-                  name: 'Incentivizes renters to resolve most maintenance tasks and collect property health info with Livaro Rewards',
-                  basic: false, pro: true, complete: true
-                },
-                {
-                  name: 'Markets your properties to self-showing prospects using live audio chat with Livaro Talk-Through',
-                  basic: false, pro: true, complete: true
-                },
-                {
-                  name: 'Handles all tenant placement and screening, rent collection, and dispute resolution with hands-off property management',
-                  basic: false, pro: false, complete: true
-                }
-              ].map((row, idx) => (
-                <tr key={idx} className="border-b">
-                  <td className="p-4">{row.name}</td>
-                  <td className="p-4 text-center">{row.basic ? "✔️" : ""}</td>
-                  <td className="p-4 text-center">{row.pro ? "✔️" : ""}</td>
-                  <td className="p-4 text-center">{row.complete ? "✔️" : ""}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          <div className="text-center mt-6">
-            <p className="text-sm text-gray-500 mb-2">*Enterprise Plan - Portfolio analytics, API access</p>
-            <button className="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700">Contact Sales for Enterprise</button>
-          </div>
+      {/* Testimonials */}
+      <div className="max-w-6xl mx-auto px-6 py-16">
+        <h2 className="text-2xl font-bold text-center mb-8">
+          Hear from Our Owners
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <blockquote className="bg-white p-6 rounded-xl shadow">
+            “Livaro helped me grow my rental portfolio with zero headaches.”
+            <footer className="mt-3 text-sm text-gray-500">— Ankit, Delhi</footer>
+          </blockquote>
+          <blockquote className="bg-white p-6 rounded-xl shadow">
+            “The automation tools changed the way I manage tenants.”
+            <footer className="mt-3 text-sm text-gray-500">— Rhea, Bangalore</footer>
+          </blockquote>
         </div>
+      </div>
+
+      {/* CTA Footer */}
+      <div className="bg-blue-50 text-center py-12 px-6">
+        <h3 className="text-xl font-semibold mb-2 text-gray-800">Need a custom plan?</h3>
+        <p className="text-gray-600 mb-4">
+          We offer tailored solutions for property managers with large portfolios.
+        </p>
+        <button className="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 transition">
+          Contact Our Team
+        </button>
       </div>
     </div>
   );

--- a/src/app/student/page.tsx
+++ b/src/app/student/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react';
 import { FaXTwitter, FaWhatsapp, FaLink } from 'react-icons/fa6';
 
-// ✅ Add this form inside the file (or import it if you separate it)
 function CustomWaitlistForm() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -12,13 +11,12 @@ function CustomWaitlistForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-        const res = await fetch('/api/waitlist' , {
+      const res = await fetch('/api/waitlist', {
         method: 'POST',
         body: JSON.stringify({ name, email }),
         headers: {
           'Content-Type': 'application/json',
         },
-        
       });
 
       if (res.ok) {
@@ -142,7 +140,30 @@ export default function StudentWaitlistPage() {
         </div>
       </div>
 
-      {/* 👇 Replace iframe with this */}
+      {/* Pricing Section */}
+      <div className="w-full max-w-4xl grid md:grid-cols-2 gap-6 mb-12">
+        {/* Basic Plan */}
+        <div className="rounded-xl border border-gray-300 bg-white p-8 shadow-md text-center">
+          <h3 className="text-xl font-semibold text-blue-700 mb-4">Basic - Free</h3>
+          <ul className="text-gray-700 space-y-2">
+            <li>2 Active Searches</li>
+            <li>10 Pre-Screen Applications</li>
+            <li>Connect Profile to Contacts</li>
+          </ul>
+        </div>
+
+        {/* Pro Plan */}
+        <div className="rounded-xl border border-gray-300 bg-white p-8 shadow-md text-center">
+          <h3 className="text-xl font-semibold text-blue-700 mb-4">Pro - $10/mo</h3>
+          <ul className="text-gray-700 space-y-2">
+            <li>10 Active Searches</li>
+            <li>Infinite Applications</li>
+            <li>Can Post Sublease Listings</li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Waitlist Form */}
       <CustomWaitlistForm />
 
       {/* FAQ Section */}


### PR DESCRIPTION
### Changes Made
- Removed "Get Started", "Start Free Trial", and "Contact Sales" buttons
- Removed pricing comparison table section
- Replaced blue background with a clean light-gray theme
- Redesigned the three plan cards with icons and minimal copy
- Added testimonial section and a soft call-to-action footer
- Modified the Student Landing page according to the Businees Model
<img width="1543" height="905" alt="image" src="https://github.com/user-attachments/assets/3beef6f0-4f66-4ddf-8e66-b96c635fbd39" />
<img width="1843" height="824" alt="image" src="https://github.com/user-attachments/assets/0e8df050-97a2-4861-a412-707d19de22e5" />
<img width="1839" height="605" alt="image" src="https://github.com/user-attachments/assets/35ff03fb-59e6-4456-b6e4-9f91e2daf633" />

