### PR TITLE
Fixed header spacing ui

### DIFF
--- a/.vscode/css_custom_data.json
+++ b/.vscode/css_custom_data.json
@@ -1,0 +1,65 @@
+{
+  "version": 1.1,
+  "atDirectives": [
+    {
+      "name": "@tailwind",
+      "description": "Use the @tailwind directive to insert Tailwind's `base`, `components`, `utilities` and `screens` styles into your CSS.",
+      "references": [
+        {
+          "name": "Tailwind CSS Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#tailwind"
+        }
+      ]
+    },
+    {
+      "name": "@apply",
+      "description": "Use @apply to inline any existing utility classes into your own custom CSS.",
+      "references": [
+        {
+          "name": "Tailwind CSS Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#apply"
+        }
+      ]
+    },
+    {
+      "name": "@layer",
+      "description": "Use the @layer directive to tell Tailwind which \"bucket\" a set of custom styles belong to.",
+      "references": [
+        {
+          "name": "Tailwind CSS Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#layer"
+        }
+      ]
+    },
+    {
+      "name": "@variants",
+      "description": "You can generate responsive, hover, focus, and other variants of your own utilities by wrapping their definitions in the @variants directive.",
+      "references": [
+        {
+          "name": "Tailwind CSS Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#variants"
+        }
+      ]
+    },
+    {
+      "name": "@responsive",
+      "description": "You can generate responsive variants of your own classes by wrapping their definitions in the @responsive directive.",
+      "references": [
+        {
+          "name": "Tailwind CSS Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#responsive"
+        }
+      ]
+    },
+    {
+      "name": "@screen",
+      "description": "The @screen directive allows you to create media queries that reference your breakpoints by name instead of duplicating their values in your own CSS.",
+      "references": [
+        {
+          "name": "Tailwind CSS Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#screen"
+        }
+      ]
+    }
+  ]
+} 

--- a/src/app/(main-layout)/map/page.tsx
+++ b/src/app/(main-layout)/map/page.tsx
@@ -5,7 +5,7 @@ import MapPageClient from "@/src/components/map/MapPageClient";
 export default function MapPage() {
   return (
     <MapContextProvider>
-      <div className="flex flex-col min-h-screen h-screen">
+      <div className="flex flex-col h-screen">
         <MapFilters />
         <MapPageClient />
       </div>

--- a/src/app/(main-layout)/messages/page.tsx
+++ b/src/app/(main-layout)/messages/page.tsx
@@ -329,7 +329,7 @@ export default function MessagesPage() {
   };
 
   return (
-    <div className="h-screen flex bg-gray-50">
+    <div className="h-screen flex bg-gray-50 mt-16">
       {/* Sidebar */}
       <div className={`${isSidebarOpen ? 'w-80' : 'w-0'} transition-all duration-300 overflow-hidden border-r border-gray-200 bg-white flex flex-col`}>
         {/* Sidebar Header */}

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -62,6 +62,10 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
   const isAuthPage =
     pathname?.includes("/sign-") || pathname?.includes("/auth");
   const showHeader = !isAuthPage || user;
+  
+  // Don't add top padding for map and messages pages since they have their own layouts
+  const isMapPage = pathname?.includes("/map");
+  const isMessagesPage = pathname?.includes("/messages");
 
   if (loading) {
     return (
@@ -82,7 +86,7 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
         Only offset content when the header is the solid authenticated version (i.e., a user is logged in).
         For guests we want the hero/landing sections to sit beneath the transparent header.
       */}
-      <main className={`${user ? 'pt-16' : ''} flex-1`}>{children}</main>
+      <main className={`${user && !isMapPage && !isMessagesPage ? 'pt-16' : ''} flex-1`}>{children}</main>
 
       {/* Footer removed as per design update */}
     </div>

--- a/src/components/map/MapFilters.tsx
+++ b/src/components/map/MapFilters.tsx
@@ -138,7 +138,7 @@ export default function MapFilters() {
   }, [filterOptions.propertyTypes]);
 
   return (
-    <div className="flex flex-wrap items-center gap-3 sm:gap-4 py-3 px-4 sm:px-6 shadow-lg z-20 bg-gradient-to-r from-white via-blue-50/20 to-white border-b border-blue-100/50 backdrop-blur-sm">
+    <div className="flex flex-wrap items-center gap-3 sm:gap-4 py-2 px-4 sm:px-6 shadow-lg z-20 bg-gradient-to-r from-white via-blue-50/20 to-white border-b border-blue-100/50 backdrop-blur-sm mt-16">
       {defaultLocation !== null ? (
         <SearchInput
           placeholder="Address, neighborhood, city, zip code"


### PR DESCRIPTION
<img width="1389" height="380" alt="Screenshot 2025-07-26 at 9 41 42 AM" src="https://github.com/user-attachments/assets/491d9b29-bcab-403c-b26d-d098bb661f20" />
<img width="1371" height="365" alt="Screenshot 2025-07-26 at 9 41 55 AM" src="https://github.com/user-attachments/assets/424d0f3b-c3eb-4575-b35c-28ed5bfd7254" />

1. Removed top padding for map and messages pages in ClientLayout
2. Added margin-top to MapFilters component to account for header height
3. Added margin-top to messages page container for proper header spacing
4. Optimized map page layout by removing redundant min-h-screen class